### PR TITLE
Adds echopype as module to the environment

### DIFF
--- a/zpls_echograms/environment.yml
+++ b/zpls_echograms/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - check-manifest
   - cmocean
   - dask[array]
+  - echopype
   - flake8
   - flake8-builtins
   - flake8-comprehensions


### PR DESCRIPTION
The echopype module is kind of important to have for a processing routine built around using it...this pull request corrects a rather embarrassing oversight.