### PR TITLE
Updates to CIW and adds AM based date limits

### DIFF
--- a/ingestions/ingest_csvs.py
+++ b/ingestions/ingest_csvs.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 """
 @author Christopher Wingard
-@brief Reworks the original datateam_ingest code in the datateam_tools 
+@brief Reworks the original datateam_ingest code in the datateam_tools
     repository to initiate ingest requests from the command line rather than
-    from a propmt and response style of request.
+    from a prompt and response style of request.
 """
 import argparse
 import netrc
@@ -12,12 +12,15 @@ import pprint
 import re
 import requests
 import sys
+import time
 
 import datetime as dt
 import dateutil.parser as date_parse
 import pandas as pd
 
 from pathlib import Path
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
 
 # initialize requests session
 HTTP_STATUS_OK = 200
@@ -27,18 +30,79 @@ HEADERS = {
 PRIORITY = 1
 
 # initialize user credentials and the OOINet base URL
-BASE_URL = 'https://ooinet.oceanobservatories.org'
+# BASE_URL = 'https://ooinet.oceanobservatories.org'
+BASE_URL = 'https://ooinet-west.oceanobservatories.org'
+DEPLOY_URL = '12587/events/deployment/inv/'
 credentials = netrc.netrc()
 API_KEY, USERNAME, API_TOKEN = credentials.authenticators('ooinet.oceanobservatories.org')
+
+# setup constants used to access the data from the different M2M interfaces
+SESSION = requests.Session()
+retry = Retry(connect=5, backoff_factor=0.5)
+adapter = HTTPAdapter(max_retries=retry)
+SESSION.mount('https://', adapter)
+
+
+def get_sensor_information(site, node, sensor, deploy):
+    """
+    Uses the metadata information available from the system for an instrument
+    deployment to obtain the asset and calibration information for the
+    specified sensor and deployment. This information is part of the sensor
+    metadata specific to that deployment.
+
+    :param site: Site name to query
+    :param node: Node name to query
+    :param sensor: Sensor name to query
+    :param deploy: Deployment number
+    :return: json object with the site-node-sensor-deployment specific sensor
+             metadata
+    """
+    r = SESSION.get(BASE_URL + '/api/m2m/' + DEPLOY_URL + site + '/' + node + '/' + sensor + '/' + str(deploy),
+                    auth=(API_KEY, API_TOKEN))
+    if r.status_code == requests.codes.ok:
+        return r.json()
+    else:
+        return None
+
+
+def get_deployment_dates(site, node, sensor, deploy):
+    """
+    Based on the site, node and sensor names and the deployment number,
+    determine the start and end times for a deployment.
+
+    :param site: Site name to query
+    :param node: Node name to query
+    :param sensor: Sensor name to query
+    :param deploy: Deployment number
+    :return: start and stop dates for the deployment of interest
+    """
+    # request the sensor deployment metadata
+    data = get_sensor_information(site, node, sensor, deploy)
+
+    # use the metadata to extract the start and end times for the deployment
+    if data:
+        start = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime(data[0]['eventStartTime'] / 1000.))
+    else:
+        return None, None
+
+    if data[0]['eventStopTime']:
+        # check to see if there is a stop time for the deployment, if so use it ...
+        stop = time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime(data[0]['eventStopTime'] / 1000.))
+    else:
+        # ... otherwise this is an active deployment, no end date
+        stop = None
+
+    return start, stop
 
 
 def load_ingest_sheet(ingest_csv, ingest_type, ingest_state):
     """
     Loads the CSV ingest sheet and sets the ingest type used in subsequent steps
-    
+
     :param ingest_csv: path and file name of the ingest CSV file to use
-    :param ingest_type: ingestion type, telemetered (recurring) or recovered 
+    :param ingest_type: ingestion type, telemetered (recurring) or recovered
         (once only)
+    :param ingest_state: ingesting state, run, stage or mock
     :return df: pandas data frame with ingestion parameters
     """
     df = pd.read_csv(ingest_csv, usecols=[0, 1, 2, 3])
@@ -53,10 +117,10 @@ def load_ingest_sheet(ingest_csv, ingest_type, ingest_state):
 
 def get_deployment_number(filename_mask):
     """
-    Pulls the deployment number out of the filename_mask field in the ingest 
+    Pulls the deployment number out of the filename_mask field in the ingest
     CSV file.
-    
-    :param filename_mask: filename mask, or regex, in the ingest CSV file that 
+
+    :param filename_mask: filename mask, or regex, in the ingest CSV file that
         includes the deployment number.
     :return deployment_number: the deployment number as an integer
     """
@@ -72,7 +136,7 @@ def build_ingest_dict(ingest_info):
     """
     Converts the pandas dataframe information into the dictionary structure
     needed for the ingest request.
-    
+
     :param ingest_info: information from the pandas dataframe to use in forming
         the ingest dictionary
     :return request_dict: ingest information structured as a dictionary
@@ -101,7 +165,7 @@ def build_ingest_dict(ingest_info):
 def ingest_data(url, key, token, data_dict):
     """
     Post the ingest request to the OOI M2M api.
-    
+
     :param url: Data ingest request URL for the M2M API
     :param key: Ingest users API key (from OOINet)
     :param token: Ingest users API token (from OOINet)
@@ -117,15 +181,15 @@ def ingest_data(url, key, token, data_dict):
 
 def main(argv=None):
     """
-    Reads data from a CSV formatted file using the ingestion CSV structure to 
+    Reads data from a CSV formatted file using the ingestion CSV structure to
     create and POST an ingest request to the OOI M2M API.
-    
+
     :param csvfile: CSV file with ingestion information
     :param ingest_type: specifies either a telemetered (recurring) or recovered
         (once only) ingest request type.
-    :param begin_date: the data must be generated by the instrument after this 
+    :param begin_date: the data must be generated by the instrument after this
         date and time (format is 'yyyy-mm-dd' or 'yyyy-mm-dd HH:MM:SS')
-    :param end_date: the data must be generated by the instrument before this 
+    :param end_date: the data must be generated by the instrument before this
         date and time (format is 'yyyy-mm-dd' or 'yyyy-mm-dd HH:MM:SS')
     :return: None, though results are saved as a CSV file in the directory the
         command is called from.
@@ -134,8 +198,8 @@ def main(argv=None):
         argv = sys.argv[1:]
 
     # initialize argument parser
-    parser = argparse.ArgumentParser(description="""Sets the source file for 
-                                                    the ingests, the type and 
+    parser = argparse.ArgumentParser(description="""Sets the source file for
+                                                    the ingests, the type and
                                                     the state.""")
 
     # assign input arguments.
@@ -147,6 +211,10 @@ def main(argv=None):
     parser.add_argument("-s", "--ingest_state", dest="ingest_state", type=str,
                         choices=('run', 'stage', 'mock'), default='run',
                         help="Ingest state, either run, stage or mock (default: run)")
+    parser.add_argument("-y", "--default_review", dest="default_review", default=False,
+                        action="store_true", help="Set the ingest reviews to default to yes, skipping the review.")
+    parser.add_argument("-am", "--use_am_dates", dest="am_dates", default=False,
+                        action='store_true', help="Use Asset Management to set start and end dates")
     parser.add_argument("-bd", "--begin_date", dest="begin_date", type=str,
                         help="Date and/or time string to set the start time of the data")
     parser.add_argument("-ed", "--end_date", dest="end_date", type=str,
@@ -159,6 +227,8 @@ def main(argv=None):
     ingest_csv = args.csvfile
     ingest_type = args.ingest_type
     ingest_state = args.ingest_state
+    default_review = args.default_review
+    am_dates = args.am_dates
     begin_date = args.begin_date
     end_date = args.end_date
 
@@ -219,30 +289,54 @@ def main(argv=None):
 
             # create the initial ingest information dictionary
             ingest_info = row[1].to_dict()
-            
-            # add the beginning date/time (the data must be generated by the 
-            # instrument after this date/time) to the dictionary, if set.
+
+            # pull the beginning and ending date/time from Asset Management and use these
+            # to bound the ingest request
+            if am_dates:
+                site, node, sensor = rd.split('-', 2)
+                start, stop = get_deployment_dates(site, node, sensor, row[1].deployment)
+                if start:
+                    ingest_info['beginData'] = start
+                if stop:
+                    ingest_info['endData'] = stop
+
+            # add the beginning date/time (the data must be generated by the
+            # instrument after this date/time) to the dictionary, if set. Note,
+            # will replace the date and time from AM if the user also requested
+            # the request use those dates.
             if begin_date:
                 begin_date = date_parse.parse(begin_date)
                 begin_date = begin_date.strftime('%Y-%m-%dT%H:%M:%S.000')
                 ingest_info['beginData'] = begin_date
-                
-            # add the ending date/time (the data must be generated by the 
+
+            # add the ending date/time (the data must be generated by the
             # instrument before this date/time) to the dictionary, if set.
+            # Note, will replace the date and time from AM if the user also
+            # requested the request use those dates.
             if end_date:
                 end_date = date_parse.parse(end_date)
                 end_date = end_date.strftime('%Y-%m-%dT%H:%M:%S.000')
                 ingest_info['endData'] = end_date
-            
+
             # build and format the ingestion dictionary
             ingest_dict = build_ingest_dict(ingest_info)
-            
-            # confirm the request, and post if correct
-            pp.pprint(ingest_dict)
-            review = input('Review ingest request. Is this correct? <y>/n: ') or 'y'
-            if 'y' in review:
+
+            # if the default review is set to True, post the request. otherwise
+            # visually review and confirm the request, and post if correct
+            if default_review:
                 r = ingest_data(BASE_URL, API_KEY, API_TOKEN, ingest_dict)
-                print(r)
+            else:
+                pp.pprint(ingest_dict)
+                review = input('Review ingest request. Is this correct? <y>/n: ') or 'y'
+                if 'y' in review:
+                    r = ingest_data(BASE_URL, API_KEY, API_TOKEN, ingest_dict)
+                    print(r)
+                else:
+                    print('Skipping this ingest request')
+                    continue
+
+            # add the ingest results to the data frame if a successful request was made
+            if r.status_code == requests.codes.ok:
                 ingest_json = r.json()
                 tdf = pd.DataFrame([ingest_json], columns=list(ingest_json.keys()))
                 tdf['ReferenceDesignator'] = row[1]['refDes']
@@ -255,15 +349,18 @@ def main(argv=None):
                 tdf['fileMask'] = row[1]['fileMask']
                 ingest_df = ingest_df.append(tdf)
             else:
-                print('Skipping this ingest request')
-                continue
+                print('Request failed with status code {}'.format(r.status_code))
+                print(r.json())
+
         else:
+            # row[1]['parserDriver'] is empty, should be commented out, but sometimes it isn't
             continue
 
     # save the results
     print(ingest_df)
     utc_time = dt.datetime.utcnow().strftime('%Y%m%d_%H%M%S')
     ingest_df.to_csv('{}_ingested.csv'.format(utc_time), index=False)
+
 
 if __name__ == '__main__':
     main()

--- a/ingestions/ingest_csvs.py
+++ b/ingestions/ingest_csvs.py
@@ -34,7 +34,7 @@ PRIORITY = 1
 BASE_URL = 'https://ooinet-west.oceanobservatories.org'
 DEPLOY_URL = '12587/events/deployment/inv/'
 credentials = netrc.netrc()
-API_KEY, USERNAME, API_TOKEN = credentials.authenticators('ooinet.oceanobservatories.org')
+API_KEY, USERNAME, API_TOKEN = credentials.authenticators('ooinet-west.oceanobservatories.org')
 
 # setup constants used to access the data from the different M2M interfaces
 SESSION = requests.Session()
@@ -325,6 +325,7 @@ def main(argv=None):
             # visually review and confirm the request, and post if correct
             if default_review:
                 r = ingest_data(BASE_URL, API_KEY, API_TOKEN, ingest_dict)
+
             else:
                 pp.pprint(ingest_dict)
                 review = input('Review ingest request. Is this correct? <y>/n: ') or 'y'
@@ -336,7 +337,7 @@ def main(argv=None):
                     continue
 
             # add the ingest results to the data frame if a successful request was made
-            if r.status_code == requests.codes.ok:
+            if r.status_code == requests.codes.created:
                 ingest_json = r.json()
                 tdf = pd.DataFrame([ingest_json], columns=list(ingest_json.keys()))
                 tdf['ReferenceDesignator'] = row[1]['refDes']


### PR DESCRIPTION
Updates the ingest request script to use dates from Asset Management for the beginData and endData options and adds a flag to process the ingest requests without a manual review. Also, changes the server to send the ingest requests to ooinet-west. Note, a combination of AM and custom begin or end dates can be used. AM dates are set first, and then replaced if a different begin or end are set. This will be useful, for example, in cases where part of the mooring broke free before the deployment ended. We can setup to ingest the first part with a custom end date, and then re-run the ingest for the remaining data with the AM date.