### PR TITLE
ingest: fixes <dataFrame>.append deprecation

### DIFF
--- a/ingestions/ingest_csvs.py
+++ b/ingestions/ingest_csvs.py
@@ -492,7 +492,7 @@ def main(argv=None):
                     tdf['priority'] = row[1]['priority']
                     tdf['refDesFinal'] = row[1]['refDesFinal']
                     tdf['fileMask'] = row[1]['fileMask']
-                    ingest_df = ingest_df.append(tdf)
+                    ingest_df = pd.concat([ingest_df, tdf])
                 else:
                     print('Request failed with status code {}'.format(r.status_code))
                     print(r.json())


### PR DESCRIPTION
The pandas data frame method <dataframe>.append(<dataframe/series>) is deprecated and pandas had began producing this warning for line 495 when running the ingest_csvs.py script.
```
./ingest_csvs.py:495: FutureWarning: The frame.append method is deprecated and will be removed from pandas
 in a future version. Use pandas.concat instead.
  ingest_df = ingest_df.append(tdf)
```
So this PR removes the call to ingest_df.append and replaces it with pd.concat.